### PR TITLE
Add Segment analytics integration

### DIFF
--- a/english_game/lib/analytics_service.dart
+++ b/english_game/lib/analytics_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// Simple analytics service that sends events to Segment.
+class AnalyticsService {
+  AnalyticsService._internal();
+
+  static final AnalyticsService instance = AnalyticsService._internal();
+
+  static const String _writeKey = 'SEGMENT_WRITE_KEY'; // Replace with real key
+
+  final http.Client _client = http.Client();
+
+  Future<void> track(String event, Map<String, dynamic> properties) async {
+    final body = jsonEncode({
+      'event': event,
+      'properties': properties,
+      'anonymousId': 'anonymous_user',
+    });
+
+    final auth = base64Encode(utf8.encode('$_writeKey:'));
+
+    try {
+      final response = await _client.post(
+        Uri.parse('https://api.segment.io/v1/track'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Basic $auth',
+        },
+        body: body,
+      );
+      if (response.statusCode >= 400) {
+        debugPrint('Failed to send analytics event: ${response.statusCode}');
+      }
+    } catch (e) {
+      debugPrint('Analytics error: $e');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple analytics service that posts events to Segment
- track `puzzle_started`, `puzzle_completed`, and `chunk_reviewed` events

## Testing
- `dart` was not available, so formatting checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_687fb07aa5b883239bc5528b700152a5